### PR TITLE
Robo command to clone and scaffold subsites

### DIFF
--- a/.ddev/config.local.yaml.example
+++ b/.ddev/config.local.yaml.example
@@ -24,7 +24,3 @@ hooks:
       auto-generated: true
     - exec: drush @basic.ddev uli
       auto-generated: true
-#    - exec: mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS umami; GRANT ALL ON umami.* to 'db'@'%';"
-#      service: db
-#    - exec: drush @umami.ddev site-install server -y --existing-config --sites-subdir=umami
-#    - exec: drush @umami.ddev uli

--- a/.ddev/config.local.yaml.example
+++ b/.ddev/config.local.yaml.example
@@ -19,9 +19,12 @@ hooks:
     - exec: drush @self.ddev uli
     - exec: mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS basic; GRANT ALL ON basic.* to 'db'@'%';"
       service: db
+      auto-generated: true
     - exec: drush @basic.ddev site-install server -y --existing-config --sites-subdir=basic
+      auto-generated: true
     - exec: drush @basic.ddev uli
-    - exec: mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS umami; GRANT ALL ON umami.* to 'db'@'%';"
-      service: db
+      auto-generated: true
+#    - exec: mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS umami; GRANT ALL ON umami.* to 'db'@'%';"
+#      service: db
 #    - exec: drush @umami.ddev site-install server -y --existing-config --sites-subdir=umami
 #    - exec: drush @umami.ddev uli

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 web/modules/contrib/
 web/themes/contrib/
 vendor/
+web/sites/*
+!web/sites/default

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ web/themes/contrib/
 vendor/
 web/sites/*
 !web/sites/default
+config/*
+!config/sync

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "web/sites/basic"]
-	path = web/sites/basic
-	url = git@github.com:Gizra/multi-repo-basic.git

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
     cp .ddev/config.local.yaml.example .ddev/config.local.yaml
     ddev restart
 
+    # Allow git inside the container to work, with your hosts's credentials.
+    # ddev auth ssh
+
+    # Fetch subsites
+    ddev exec "cd .. && ./vendor/bin/robo fetch ./robo/sites-collection1.csv"
+
 Every time you want to re-install:
 
     ddev restart

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Every time you want to re-install:
 
     ddev restart
 
+To re-fetch subsites
+
+    ddev exec "cd .. && ./vendor/bin/robo fetch ./robo/sites-collection1.csv" && ddev restart
+
+To clean the working directory after a re-fetch
+
+    ddev exec "cd .. && ./vendor/bin/robo reset"
 
 Notice that in the end of the `ddev restart` we get a one time admin link to login, to two sites:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     ddev restart
 
     # Allow git inside the container to work, with your hosts's credentials.
-    # ddev auth ssh
+    ddev auth ssh
 
     # Fetch subsites
     ddev exec "cd .. && ./vendor/bin/robo fetch ./robo/sites-collection1.csv" && ddev restart

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     # ddev auth ssh
 
     # Fetch subsites
-    ddev exec "cd .. && ./vendor/bin/robo fetch ./robo/sites-collection1.csv"
+    ddev exec "cd .. && ./vendor/bin/robo fetch ./robo/sites-collection1.csv" && ddev restart
 
 Every time you want to re-install:
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
     # Fetch subsites
     ddev exec "cd .. && ./vendor/bin/robo fetch ./robo/sites-collection1.csv" && ddev restart
 
+
+
 Every time you want to re-install:
 
     ddev restart
@@ -23,6 +25,11 @@ Every time you want to re-install:
 To re-fetch subsites
 
     ddev exec "cd .. && ./vendor/bin/robo fetch ./robo/sites-collection1.csv" && ddev restart
+
+Note it is possibly to execute this also from the host, with
+
+    ./vendor/bin/robo fetch ./robo/sites-collection1.csv && ddev restart
+
 
 To clean the working directory after a re-fetch
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,11 @@
     cd multi-repo
     ddev composer install
     cp .ddev/config.local.yaml.example .ddev/config.local.yaml
-    ddev restart
-
     # Allow git inside the container to work, with your hosts's credentials.
     ddev auth ssh
-
     # Fetch subsites
-    ddev exec "cd .. && ./vendor/bin/robo fetch ./robo/sites-collection1.csv" && ddev restart
-
-
+    ddev exec "cd .. && ./vendor/bin/robo fetch ./robo/sites-collection1.csv"
+    ddev restart
 
 Every time you want to re-install:
 

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -86,7 +86,7 @@ class RoboFile extends \Robo\Tasks
       $path = "web/sites/$name";
 
       // Clone sub-site.
-      $task->exec("git clone --branch $branch $git $path");
+      $task->exec("git clone $git $path --branch=$branch");
     }
 
     $task->run();
@@ -164,6 +164,7 @@ class RoboFile extends \Robo\Tasks
       ->taskExecStack()
       ->stopOnFail()
       ->exec('git reset --hard HEAD')
+      ->exec('git clean -fd')
       ->exec('git status')
       ->run();
   }

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -104,8 +104,9 @@ class RoboFile extends \Robo\Tasks
       list($name,,) = $row;
       $path = "web/sites/$name";
 
-      // Create symlink.
-      $this->_symlink($path, "config/$name");
+      // Create symlink. We have `../path`, as the symlink needs a relative
+      // path.
+      $this->_symlink("../$path", "config/$name");
 
       // Copy an adapted `settings.php`
       $this->_copy('robo/settings.php', $path.'/settings.php', true);

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -21,7 +21,7 @@ class RoboFile extends \Robo\Tasks
       ->run();
 
     if ($result->getMessage()) {
-      // throw new Exception('The working directory is dirty. Please commit any pending changes.');
+      throw new Exception('The working directory is dirty. Please commit any pending changes.');
     }
 
     // Remove directories under web/sites.
@@ -64,34 +64,6 @@ class RoboFile extends \Robo\Tasks
       $task->run();
     }
 
-    return;
-
-    $gitmodules = file_get_contents('.gitmodules');
-    preg_match_all(self::GITMODULES_REGEX, $gitmodules, $matches);
-
-    if (empty($matches[1])) {
-      throw new Exception('No directories found in .gitmodules');
-    }
-
-    $directoryNames = $matches[1];
-
-    $task = $this
-      ->taskExecStack()
-      ->stopOnFail();
-
-    // Delete symlinks.
-    foreach ($directoryNames as $directoryName) {
-      $task->exec('rm config/'.$directoryName);
-
-      $path = "web/sites/$directoryName";
-
-      $task->exec("git submodule deinit -f -- $path");
-      $task->exec("rm -rf .git/modules/$path");
-      $task->exec("git rm $path");
-    }
-
-    $task->run();
-
     // Get new subsites from file.
     $subSites = [];
     if (($handle = fopen($filename, 'r')) !== FALSE) {
@@ -112,11 +84,9 @@ class RoboFile extends \Robo\Tasks
       $branch = $branch ?: 'master';
 
       $path = "web/sites/$name";
-      // Cleanup folder if in case we already have an older version.
-      $task->exec("rm -rf $path");
 
-      // Add submodule.
-      $task->exec("git submodule add --force -b $branch $git $path");
+      // Clone sub-site.
+      $task->exec("git clone --branch $branch $git $path");
     }
 
     $task->run();

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -29,7 +29,9 @@ class RoboFile extends \Robo\Tasks
     $finder
       ->directories()
       ->in('web/sites')
-      ->exclude('default');
+      ->exclude('default')
+      // Don't search sub-directories.
+      ->depth('== 0');
 
     if ($finder->hasResults()) {
       $task = $this
@@ -49,7 +51,9 @@ class RoboFile extends \Robo\Tasks
     $finder
       ->files()
       ->in('config')
-      ->exclude('sync');
+      ->exclude('sync')
+      // Don't search sub-directories.
+      ->depth('== 0');
 
     if ($finder->hasResults()) {
       $task = $this

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -1,0 +1,160 @@
+<?php
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * This is project's console commands configuration for Robo task runner.
+ *
+ * @see http://robo.li/
+ */
+class RoboFile extends \Robo\Tasks
+{
+
+  const GITMODULES_REGEX = '/\[submodule "web\/sites\/(.*)"\]/';
+
+  public function fetch(string $filename)
+  {
+    $result = $this
+      ->taskExec('git status -s')
+      ->printOutput(FALSE)
+      ->run();
+
+    if ($result->getMessage()) {
+      throw new Exception('The working directory is dirty. Please commit any pending changes.');
+    }
+
+    // Remove directories.
+    $gitmodules = file_get_contents('.gitmodules');
+    preg_match_all(self::GITMODULES_REGEX, $gitmodules, $matches);
+
+    if (empty($matches[1])) {
+      throw new Exception('No directories found in .gitmodules');
+    }
+
+    $directoryNames = $matches[1];
+
+    $task = $this
+      ->taskExecStack()
+      ->stopOnFail();
+
+    // Delete symlinks.
+    foreach ($directoryNames as $directoryName) {
+      $task->exec('rm config/'.$directoryName);
+
+      $path = "web/sites/$directoryName";
+
+      $task->exec("git submodule deinit -f -- $path");
+      $task->exec("rm -rf .git/modules/$path");
+      $task->exec("git rm $path");
+    }
+
+    $task->run();
+
+    // Get new subsites from file.
+    $subSites = [];
+    if (($handle = fopen($filename, 'r')) !== FALSE) {
+      while (($data = fgetcsv($handle)) !== FALSE) {
+        $subSites[] = $data;
+      }
+      fclose($handle);
+    }
+
+    // Add sub-modules
+    $task = $this
+      ->taskExecStack()
+      ->stopOnFail();
+
+    foreach ($subSites as $row) {
+      list($name, $git, $branch) = $row;
+
+      $branch = $branch ?: 'master';
+
+      $path = "web/sites/$name";
+      // Cleanup folder if in case we already have an older version.
+      $task->exec("rm -rf $path");
+
+      // Add submodule.
+      $task->exec("git submodule add --force -b $branch $git $path");
+    }
+
+    $task->run();
+
+    // Adapt DDEV config
+    $ddevFilename = '.ddev/config.local.yaml.example';
+    $ddevConfig = Yaml::parseFile($ddevFilename);
+    $ddevConfig['additional_hostnames'] = [];
+
+    foreach ($subSites as $row) {
+      list($name,,) = $row;
+      $path = "web/sites/$name";
+
+      // Create symlink.
+      $this->_symlink($path, "config/$name");
+
+      // Copy an adapted `settings.php`
+      $this->_copy('robo/settings.php', $path.'/settings.php', true);
+
+      $this->taskReplaceInFile("$path/settings.php")
+        ->from('{{ name }}')
+        ->to($name)
+        ->run();
+
+      $ddevConfig['additional_hostnames'][] = $name;
+    }
+
+    // Remove previous DDEV `post-start` commands.
+    foreach ($ddevConfig['hooks']['post-start'] as $index => $row) {
+      if (!empty($row['auto-generated'])) {
+        unset($ddevConfig['hooks']['post-start'][$index]);
+      }
+    }
+
+    // Add new DDEV `post-start` commands.
+    foreach ($subSites as $row) {
+      list($name,,) = $row;
+
+      $newRows = [
+        [
+          'exec' => "mysql -uroot -proot -e \"CREATE DATABASE IF NOT EXISTS $name; GRANT ALL ON basic.* to 'db'@'%';\"",
+          'service' => 'db',
+          'auto-generated' => true,
+        ],
+
+        [
+          'exec' => "drush @$name.ddev site-install server -y --existing-config --sites-subdir=$name",
+          'auto-generated' => true,
+        ],
+
+        [
+          'exec' => "drush @$name.ddev uli",
+          'auto-generated' => true,
+        ],
+      ];
+
+      $ddevConfig['hooks']['post-start'] = array_merge($ddevConfig['hooks']['post-start'], $newRows);
+    }
+
+    $yaml = Yaml::dump($ddevConfig);
+    file_put_contents($ddevFilename, $yaml);
+
+    $this->_copy($ddevFilename, '.ddev/config.local.yaml', true);
+
+    // Restart DDEV.
+    $this->_exec('ddev restart');
+
+  }
+
+  /**
+   * Reset directory and git after running the `fetch` command.
+   */
+  public function reset() {
+    $this
+      ->taskExecStack()
+      ->stopOnFail()
+      ->exec('git reset --hard HEAD')
+      ->exec('git clean -fd')
+      ->exec('git submodule update --init --recursive --force')
+      ->exec('git status')
+      ->run();
+  }
+}

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -150,10 +150,6 @@ class RoboFile extends \Robo\Tasks
     file_put_contents($ddevFilename, $yaml);
 
     $this->_copy($ddevFilename, '.ddev/config.local.yaml', true);
-
-    // Restart DDEV.
-    $this->_exec('ddev restart');
-
   }
 
   /**

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -11,8 +11,6 @@ use Symfony\Component\Yaml\Yaml;
 class RoboFile extends \Robo\Tasks
 {
 
-  const GITMODULES_REGEX = '/\[submodule "web\/sites\/(.*)"\]/';
-
   public function fetch(string $filename)
   {
     $result = $this

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "drush/drush": "^10.2"
     },
     "require-dev": {
+        "consolidation/robo": "^1.0.0"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/config/basic
+++ b/config/basic
@@ -1,1 +1,0 @@
-../web/sites/basic/config/basic

--- a/drush/.gitignore
+++ b/drush/.gitignore
@@ -1,0 +1,2 @@
+!sites/self.site.yml
+sites/

--- a/drush/sites/basic.site.yml
+++ b/drush/sites/basic.site.yml
@@ -1,3 +1,0 @@
-ddev:
-  root: /var/www/html/web/sites/basic
-  uri: https://basic.ddev.site:4443

--- a/drush/sites/umami.site.yml
+++ b/drush/sites/umami.site.yml
@@ -1,3 +1,0 @@
-ddev:
-  root: /var/www/html/web/sites/umami
-  uri: https://umami.ddev.site:4443

--- a/robo/drush.site.yml
+++ b/robo/drush.site.yml
@@ -1,0 +1,3 @@
+ddev:
+  root: /var/www/html/web/sites/{{ name }}
+  uri: https://{{ name }}.ddev.site:4443

--- a/robo/settings.php
+++ b/robo/settings.php
@@ -3,4 +3,5 @@ include $app_root . '/sites/default/settings.php';
 if (file_exists($app_root . '/sites/default/settings.ddev.php')) {
   include $app_root . '/sites/default/settings.ddev.php';
 }
-$databases['default']['default']['database'] = 'umami';
+$databases['default']['default']['database'] = '{{ name }}';
+$config['config_split.config_split.{{ name }}']['status'] = TRUE;

--- a/robo/sites-collection1.csv
+++ b/robo/sites-collection1.csv
@@ -1,2 +1,1 @@
 basic,git@github.com:Gizra/multi-repo-basic.git,remove-settings
-foo,git@github.com:Gizra/multi-repo-basic.git,remove-settings

--- a/robo/sites-collection1.csv
+++ b/robo/sites-collection1.csv
@@ -1,0 +1,2 @@
+basic,git@github.com:Gizra/multi-repo-basic.git,remove-settings
+foo,git@github.com:Gizra/multi-repo-basic.git,remove-settings


### PR DESCRIPTION
This is another take without the complexity of git-submodules which is shown in https://github.com/Gizra/multi-repo/pull/4

Disadvantage here is that git doesn't keep track of which subsites we had and which revision. On the other hand - and its a big one - we don't have to mess with git-submodules.

Instead Robo just `git clone`s the sub-sites and with `.gitignore` we make sure the base repo doesn't get confused with those new repos.

Another improvement is that the robo is executed from ddev itself, and not the host, thus removing the need for the host to have latest PHP and extensions installed.
By running `ddev auth ssh` once, we're able to use git with the host credentials. So all that remains is:

`ddev exec "cd .. && ./vendor/bin/robo fetch ./robo/sites-collection1.csv" && ddev restart`

[![asciicast](https://asciinema.org/a/iZvC84Tiu6TP3307NWdXoIEW2.svg)](https://asciinema.org/a/iZvC84Tiu6TP3307NWdXoIEW2)

and cleanup:

`ddev exec "cd .. && ./vendor/bin/robo reset"`

## Future Improvements

I can imagine adding in Robo some `$this->ask("What is the Git URL?");`, so sub-site owners could easily scaffold their new site.

